### PR TITLE
Relax maximum allowed Groovy version in snapshot builds (#1108)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
   groovyConsoleExtraDependencies = [
     "org.codehaus.groovy:groovy-console:${groovyVersion}"
   ]
-  maxGroovyVersion = snapshotVersion ? "3.9.99" : maxGroovyVersion
+  maxGroovyVersion = snapshotVersion ? "9.9.99" : maxGroovyVersion
   if (System.getProperty("groovyVersion")) {
     groovyVersion = System.getProperty("groovyVersion")
   }


### PR DESCRIPTION
To do not prevent from playing with Groovy 4.x when alpha is released.